### PR TITLE
Replace Facebook auth with GitHub and add filestore session storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Local config
 config.js
+/sessions
 
 # Rest adapted from https://www.gitignore.io/api/vim,node,linux,macos,emacs,windows,ansible,database,webstorm,visualstudiocode
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NUSMods Launchpad
 
-Deployment dashboard for NUSMods - http://launch.nusmods.com
+Deployment dashboard for NUSMods - https://launch.nusmods.com
 
 ![Demo](screenshots/demo.png)
 
@@ -9,7 +9,8 @@ Deployment dashboard for NUSMods - http://launch.nusmods.com
 ```sh
 $ yarn
 $ cp config.example.js config.js
-# Create FB app and replace config with app ID and secret.
+# Create GitHub Oauth app and replace config with app ID and secret.
+# You can also ask for our development ID and secret if you don't want to create one yourself
 # If desired, create Slack app and replace config with API token and target channel IDs.
 $ npm start
 $ open http://localhost:3000
@@ -18,7 +19,7 @@ $ open http://localhost:3000
 ## Deployment
 
 ```sh
-$ npm run forever
+$ pm2 start ecosystem.config.js
 ```
 
 ## License

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,60 @@
+const passport = require('passport');
+const session = require('express-session');
+const GitHubStrategy = require('passport-github').Strategy;
+const config = require('./config');
+
+// Configure GitHub strategy for use by Passport.
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: config.githubClientId,
+      clientSecret: config.githubClientSecret,
+      callbackURL: `${config.host}/login/github/callback`,
+      userAgent: 'nusmods-launchpad',
+    },
+    (accessToken, refreshToken, profile, cb) => {
+      // Ensure only whitelisted GitHub users can log in
+      if (!config.githubUsernames.includes(profile.username)) {
+        const authError = new Error('Username not recognized');
+        authError.status = 403;
+        return cb(authError);
+      }
+
+      return cb(null, profile);
+    },
+  ),
+);
+
+// Configure Passport authenticated session persistence.
+passport.serializeUser((user, cb) => {
+  cb(null, user);
+});
+
+passport.deserializeUser((obj, cb) => {
+  cb(null, obj);
+});
+
+module.exports = function auth(app) {
+  app.use(
+    session({
+      secret: config.sessionSecret,
+      resave: true,
+      saveUninitialized: true,
+    }),
+  );
+
+  // Initialize Passport and restore authentication state, if any, from the
+  // session.
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  app.get('/login/github', passport.authenticate('github'));
+
+  app.get(
+    '/login/github/callback',
+    passport.authenticate('github', { failureRedirect: '/' }),
+    (req, res) => {
+      res.redirect('/');
+    },
+  );
+};

--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,8 @@
 const passport = require('passport');
 const session = require('express-session');
+const FileStore = require('session-file-store')(session);
 const GitHubStrategy = require('passport-github').Strategy;
+
 const config = require('./config');
 
 // Configure GitHub strategy for use by Passport.
@@ -40,6 +42,7 @@ module.exports = function auth(app) {
       secret: config.sessionSecret,
       resave: true,
       saveUninitialized: true,
+      store: new FileStore(),
     }),
   );
 

--- a/config.example.js
+++ b/config.example.js
@@ -1,12 +1,30 @@
 module.exports = {
-  repo: '/Users/yangshun/Developer/nusmods/',
-  app: '/Users/yangshun/Developer/nusmods/www',
-  stagingDir: '/Users/yangshun/Developer/nusmods/www/dist',
-  productionDir: '/Users/yangshun/Developer/nusmods.com',
+  // Location of the NUSMods repo root and the website root on the local filesystem
+  repo: `${process.env.HOME}/Developer/nusmods/`,
+  app: `${process.env.HOME}/Developer/nusmods/www`,
+
+  // Location of the NUSMods website files for staging and production on the local filesystem
+  stagingDir: `${process.env.HOME}/Developer/nusmods/www/dist`,
+  productionDir: `${process.env.HOME}/Developer/nusmods.com`,
+
+  // Where Launchpad will be served from
   host: 'http://localhost:3000',
+
+  // Generate a long, randomly generated string to encrypt login sessions
   sessionSecret: 'RANDOMLY GENERATED KEY',
+
+  // The Slack API token and the channel on which the updates will be posted
   slackBroadcastChannels: ['nusmods'],
   slackAPIToken: 'SLACK_TOKEN',
-  facebookAppID: 'APP_ID',
-  facebookAppSecret: 'APP_SECRET',
+
+  // GitHub app client ID and secret from https://github.com/organizations/nusmodifications/settings/applications
+  // and a whitelist of users allowed to access the app
+  githubClientId: 'CLIENT_ID',
+  githubClientSecret: 'CLIENT_SECRET',
+  githubUsernames: [
+    'ZhangYiJiang',
+    'taneliang',
+    'li-kai',
+    'jiholim',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "morgan": "^1.9.1",
     "nodegit": "^0.24.1",
     "passport": "^0.4.0",
-    "passport-facebook": "^2.1.1",
+    "passport-github": "^1.1.0",
     "pug": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "nodegit": "^0.24.1",
     "passport": "^0.4.0",
     "passport-github": "^1.1.0",
-    "pug": "^2.0.3"
+    "pug": "^2.0.3",
+    "session-file-store": "^1.2.0"
   },
   "devDependencies": {
     "prettier": "^1.16.4"

--- a/server.js
+++ b/server.js
@@ -39,4 +39,7 @@ app.use(
   commits.router,
 );
 
-app.listen(process.env.PORT || 3000);
+const port = process.env.PORT || 3000;
+app.listen(port);
+
+console.log(`Server started on port ${port}`);

--- a/server.js
+++ b/server.js
@@ -1,54 +1,11 @@
 const express = require('express');
-const passport = require('passport');
-const Strategy = require('passport-facebook').Strategy;
-const config = require('./config');
+const ensureLoggedIn = require('connect-ensure-login');
 
 const path = require('path');
 
 const dashboard = require('./routes/dashboard');
 const commits = require('./routes/commits');
-
-// Configure the Facebook strategy for use by Passport.
-//
-// OAuth 2.0-based strategies require a `verify` function which receives the
-// credential (`accessToken`) for accessing the Facebook API on the user's
-// behalf, along with the user's profile.  The function must invoke `cb`
-// with a user object, which will be set at `req.user` in route handlers after
-// authentication.
-passport.use(
-  new Strategy(
-    {
-      clientID: config.facebookAppID,
-      clientSecret: config.facebookAppSecret,
-      callbackURL: `${config.host}/login/facebook/return`,
-    },
-    (accessToken, refreshToken, profile, cb) => {
-      // In this example, the user's Facebook profile is supplied as the user
-      // record.  In a production-quality application, the Facebook profile should
-      // be associated with a user record in the application's database, which
-      // allows for account linking and authentication with other identity
-      // providers.
-      return cb(null, profile);
-    },
-  ),
-);
-
-// Configure Passport authenticated session persistence.
-//
-// In order to restore authentication state across HTTP requests, Passport needs
-// to serialize users into and deserialize users out of the session.  In a
-// production-quality application, this would typically be as simple as
-// supplying the user ID when serializing, and querying the user record by ID
-// from the database when deserializing.  However, due to the fact that this
-// example does not have a database, the complete Facebook profile is serialized
-// and deserialized.
-passport.serializeUser((user, cb) => {
-  cb(null, user);
-});
-
-passport.deserializeUser((obj, cb) => {
-  cb(null, obj);
-});
+const auth = require('./auth');
 
 // Create a new Express application.
 const app = express();
@@ -62,34 +19,15 @@ app.set('view engine', 'pug');
 app.use(require('morgan')('combined'));
 app.use(require('cookie-parser')());
 app.use(require('body-parser').urlencoded({ extended: true }));
-app.use(
-  require('express-session')({
-    secret: config.sessionSecret,
-    resave: true,
-    saveUninitialized: true,
-  }),
-);
+
+auth(app);
+
 app.use(express.static(path.join(__dirname, 'public')));
-
-// Initialize Passport and restore authentication state, if any, from the
-// session.
-app.use(passport.initialize());
-app.use(passport.session());
-
-app.get('/login/facebook', passport.authenticate('facebook'));
-
-app.get(
-  '/login/facebook/return',
-  passport.authenticate('facebook', { failureRedirect: '/' }),
-  (req, res) => {
-    res.redirect('/');
-  },
-);
 
 app.use('/', dashboard);
 app.use(
   '/commits',
-  require('connect-ensure-login').ensureLoggedIn('/'),
+  ensureLoggedIn.ensureLoggedIn('/'),
   (req, res, next) => {
     // Do not allow any actions if there is an ongoing build.
     if (commits.ongoingBuild) {

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -11,7 +11,8 @@ block content
         div
           unless isLoggedIn
             div.text-right
-              a(href='/login/facebook', class='btn btn-primary btn-sm') Facebook Login
+              a(href='/login/github', class='btn btn-sm btn-primary') GitHub Login
+
           else
             div
               div.text-right

--- a/views/login.pug
+++ b/views/login.pug
@@ -9,5 +9,5 @@ block content
       h4 Launchpad
     br
     div
-      a(href='/login/facebook', class='btn btn-primary') Facebook Login
+      a(href='/login/github', class='btn btn-primary') GitHub Login
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,9 +1201,10 @@ parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
-passport-facebook@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/passport-facebook/-/passport-facebook-2.1.1.tgz#c39d0b52ae4d59163245a4e21a7b9b6321303311"
+passport-github@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/passport-github/-/passport-github-1.1.0.tgz#8ce1e3fcd61ad7578eb1df595839e4aea12355d4"
+  integrity sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=
   dependencies:
     passport-oauth2 "1.x.x"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,6 +179,11 @@ axios@^0.18.0:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
+bagpipe@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/bagpipe/-/bagpipe-0.3.5.tgz#e341d164fcb24cdf04ea7e05b765ec10c8aea6a1"
+  integrity sha1-40HRZPyyTN8E6n4Ft2XsEMiupqE=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -605,6 +610,15 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
+fs-extra@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -667,6 +681,11 @@ glob@^7.0.3, glob@^7.0.5:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+graceful-fs@^4.1.11:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -741,6 +760,11 @@ ignore-walk@^3.0.1:
   integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
   dependencies:
     minimatch "^3.0.4"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1118,7 +1142,7 @@ oauth@0.9.x:
   version "0.9.15"
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1511,6 +1535,11 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.5"
 
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -1582,6 +1611,17 @@ serve-static@1.13.2:
     parseurl "~1.3.2"
     send "0.16.2"
 
+session-file-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/session-file-store/-/session-file-store-1.2.0.tgz#35a994a7fb0cbf7f784067bf9059939c520b7c44"
+  integrity sha512-DkYLYFkkK6u9xyraVHemulhlUuuufLukf7SQxOZSx8SPwkswcaIrls882PaQZ72zRKsyhUVNxOUl9w0lQubUFw==
+  dependencies:
+    bagpipe "^0.3.5"
+    fs-extra "^4.0.0"
+    object-assign "^4.1.1"
+    retry "^0.10.0"
+    write-file-atomic "1.3.1"
+
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -1597,6 +1637,11 @@ setprototypeof@1.1.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
 source-map@0.5.x, source-map@~0.5.1:
   version "0.5.7"
@@ -1845,6 +1890,15 @@ wordwrap@0.0.2:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-atomic@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.1.tgz#7d45ba32316328dd1ec7d90f60ebc0d845bb759a"
+  integrity sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
Remove Facebook auth because, well, it's a bit odd for this app to use Facebook instead of GitHub which we all have accounts on. Go to https://github.com/organizations/nusmodifications/settings/applications to see the client ID and secret used in `config.js`. 

Uses a whitelist of GitHub usernames to ensure only core developer team members have access. I wanted to try to grab the list of users from https://github.com/orgs/nusmodifications/teams/nusmods-developers, but strangely this requires authentication even though as far as I know this information is actually public. 

Also add `session-file-store` - the default session store is meant for development only, and is likely the source of our memory leak. This should hopefully fix that. 